### PR TITLE
Add category budget tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A responsive expense tracker built with Vue 3 (Composition API), Vite, Pinia, Vu
 ## Features
 - Add, edit, and delete expenses (description, category, amount, date)
 - Dashboard summary: total spent, top category, transaction count
+- Category-level monthly budgets with progress bars and over-budget alerts
 - Filters by category and month
 - Reports with pie (category breakdown) and bar (monthly trend) charts
 - Smooth transitions, responsive UI, modern Tailwind design
@@ -26,10 +27,11 @@ Open the dev server URL printed in the terminal.
 
 ## Project Structure
 - `src/store/expenses.js`: Pinia store with seed data and persistence
-- `src/components/`: `ExpenseForm.vue`, `ExpenseList.vue`, `SummaryCards.vue`, `Charts.vue`
+- `src/components/`: `ExpenseForm.vue`, `ExpenseList.vue`, `SummaryCards.vue`, `BudgetPlanner.vue`, `Charts.vue`
 - `src/views/`: `Dashboard.vue`, `AddExpense.vue`, `Reports.vue`
 - `src/router.js`: Routes `/`, `/add`, `/reports`
 
 ## Notes
 - Seed data is injected on first run; subsequent changes persist in LocalStorage.
 - Currency formatting defaults to the browser locale.
+- Budget limits are stored separately from expenses so users can adjust goals without changing transaction history.

--- a/src/components/BudgetPlanner.vue
+++ b/src/components/BudgetPlanner.vue
@@ -1,0 +1,68 @@
+<script setup>
+import { computed, reactive } from 'vue'
+import { useExpensesStore } from '../store/expenses'
+
+const store = useExpensesStore()
+
+const form = reactive({
+  category: store.categories[0] || 'Food',
+  amount: '',
+})
+
+const budgetRows = computed(() => store.budgetProgress)
+const hasBudgets = computed(() => budgetRows.value.length > 0)
+
+function saveBudget() {
+  const amount = Number(form.amount)
+  if (!form.category || Number.isNaN(amount) || amount < 0) return
+  store.setBudget(form.category, amount)
+  form.amount = ''
+}
+
+function removeBudget(category) {
+  store.removeBudget(category)
+}
+</script>
+
+<template>
+  <section class="bg-white rounded-lg shadow p-4 space-y-4">
+    <div class="flex flex-col gap-1">
+      <p class="text-xs uppercase tracking-wide text-gray-500">Monthly Budget Planner</p>
+      <h3 class="text-lg font-semibold">Stay ahead of category spending</h3>
+      <p class="text-sm text-gray-500">Budgets apply to the currently selected month. Choose a month filter to inspect previous periods.</p>
+    </div>
+
+    <form class="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-3" @submit.prevent="saveBudget">
+      <label class="sr-only" for="budget-category">Budget category</label>
+      <select id="budget-category" v-model="form.category" class="px-3 py-2 rounded-md border border-gray-300 bg-white">
+        <option v-for="category in store.categories" :key="category" :value="category">{{ category }}</option>
+      </select>
+
+      <label class="sr-only" for="budget-amount">Budget amount</label>
+      <input id="budget-amount" v-model.number="form.amount" type="number" min="0" step="0.01" class="px-3 py-2 rounded-md border border-gray-300" placeholder="Monthly limit" />
+
+      <button type="submit" class="px-4 py-2 rounded-md bg-primary text-white hover:opacity-90 transition">Save Budget</button>
+    </form>
+
+    <div v-if="hasBudgets" class="space-y-3">
+      <div v-for="row in budgetRows" :key="row.category" class="space-y-1.5">
+        <div class="flex items-center justify-between gap-3 text-sm">
+          <div>
+            <p class="font-medium">{{ row.category }}</p>
+            <p class="text-gray-500">{{ store.formatCurrency(row.spent) }} of {{ store.formatCurrency(row.limit) }}</p>
+          </div>
+          <div class="flex items-center gap-3">
+            <span class="font-semibold" :class="row.overBudget ? 'text-red-600' : 'text-gray-700'">{{ row.percent.toFixed(0) }}%</span>
+            <button type="button" class="text-xs text-red-600 hover:underline" @click="removeBudget(row.category)">Remove</button>
+          </div>
+        </div>
+        <div class="h-2 rounded-full bg-gray-100 overflow-hidden">
+          <div class="h-full rounded-full transition-all" :class="row.overBudget ? 'bg-red-500' : row.percent >= 80 ? 'bg-amber-500' : 'bg-green-500'" :style="{ width: `${Math.min(row.percent, 100)}%` }"></div>
+        </div>
+        <p v-if="row.overBudget" class="text-xs text-red-600">Over budget by {{ store.formatCurrency(row.spent - row.limit) }}.</p>
+      </div>
+    </div>
+
+    <p v-else class="text-sm text-gray-500">No budgets yet. Add category limits to unlock progress tracking and alerts.</p>
+  </section>
+</template>

--- a/src/store/expenses.js
+++ b/src/store/expenses.js
@@ -3,6 +3,7 @@ import { format, parseISO } from 'date-fns'
 
 const STORAGE_KEY = 'budget_analyzer_expenses_v1'
 const SETTINGS_KEY = 'budget_analyzer_settings_v1'
+const BUDGETS_KEY = 'budget_analyzer_budgets_v1'
 
 function loadFromStorage() {
   try {
@@ -38,6 +39,23 @@ function saveSettings(settings) {
   }
 }
 
+function loadBudgets() {
+  try {
+    const raw = localStorage.getItem(BUDGETS_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function saveBudgets(budgets) {
+  try {
+    localStorage.setItem(BUDGETS_KEY, JSON.stringify(budgets))
+  } catch {
+    // ignore
+  }
+}
+
 function seedData() {
   const today = new Date()
   const sample = [
@@ -62,6 +80,7 @@ export const useExpensesStore = defineStore('expenses', {
     settings: {
       currency: 'USD', // 'USD', 'NGN', 'GBP'
     },
+    budgets: {},
   }),
   getters: {
     filteredExpenses(state) {
@@ -88,6 +107,22 @@ export const useExpensesStore = defineStore('expenses', {
         buckets[month] = (buckets[month] || 0) + Number(e.amount)
       }
       return Object.entries(buckets).sort(([a], [b]) => (a > b ? 1 : -1))
+    },
+    budgetProgress(state) {
+      return Object.entries(state.budgets)
+        .filter(([, limit]) => Number(limit) > 0)
+        .map(([category, limit]) => {
+          const spent = this.filteredExpenses
+            .filter((e) => e.category === category)
+            .reduce((sum, e) => sum + Number(e.amount || 0), 0)
+          const numericLimit = Number(limit)
+          const percent = numericLimit > 0 ? (spent / numericLimit) * 100 : 0
+          return { category, limit: numericLimit, spent, percent, remaining: numericLimit - spent, overBudget: spent > numericLimit }
+        })
+        .sort((a, b) => b.percent - a.percent)
+    },
+    budgetAlerts() {
+      return this.budgetProgress.filter((row) => row.percent >= 80)
     },
     topCategory() {
       const byCat = this.spendByCategory
@@ -119,6 +154,12 @@ export const useExpensesStore = defineStore('expenses', {
         this.settings.currency = settings.currency
       } else {
         saveSettings(this.settings)
+      }
+      const budgets = loadBudgets()
+      if (budgets && typeof budgets === 'object' && !Array.isArray(budgets)) {
+        this.budgets = budgets
+      } else {
+        saveBudgets(this.budgets)
       }
     },
     validate(payload) {
@@ -161,6 +202,20 @@ export const useExpensesStore = defineStore('expenses', {
     setCurrency(code) {
       this.settings.currency = code
       saveSettings(this.settings)
+    },
+    setBudget(category, amount) {
+      const numericAmount = Number(amount)
+      if (!category || Number.isNaN(numericAmount) || numericAmount < 0) return
+      if (numericAmount === 0) {
+        delete this.budgets[category]
+      } else {
+        this.budgets[category] = numericAmount
+      }
+      saveBudgets(this.budgets)
+    },
+    removeBudget(category) {
+      delete this.budgets[category]
+      saveBudgets(this.budgets)
     },
     formatCurrency(value) {
       try {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -4,6 +4,7 @@ import { useExpensesStore } from '../store/expenses'
 import SummaryCards from '../components/SummaryCards.vue'
 import ExpenseList from '../components/ExpenseList.vue'
 import Charts from '../components/Charts.vue'
+import BudgetPlanner from '../components/BudgetPlanner.vue'
 
 const store = useExpensesStore()
 const selectedCategory = ref('All')
@@ -52,6 +53,7 @@ function applyFilters() {
         <ExpenseList :expenses="store.filteredExpenses.slice(0, 8)" showHeader title="Recent Transactions" />
       </div>
       <div class="space-y-4">
+        <BudgetPlanner />
         <Charts type="pie" />
         <Charts type="bar" />
       </div>

--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -15,6 +15,7 @@ onMounted(() => {
 
 const categories = computed(() => ['All', ...store.categories])
 const months = computed(() => store.monthsAvailable)
+const alerts = computed(() => store.budgetAlerts)
 
 function applyFilters() {
   store.setFilterCategory(selectedCategory.value)
@@ -37,6 +38,23 @@ function applyFilters() {
         <option v-for="m in months" :key="m" :value="m">{{ m }}</option>
       </select>
     </div>
+
+    <section class="bg-white rounded-lg shadow p-4 space-y-3">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <p class="text-xs uppercase tracking-wide text-gray-500">Budget Health</p>
+          <h3 class="font-semibold">Categories near or above budget</h3>
+        </div>
+        <RouterLink to="/" class="text-sm text-primary">Manage budgets</RouterLink>
+      </div>
+      <ul v-if="alerts.length" class="divide-y divide-gray-100">
+        <li v-for="alert in alerts" :key="alert.category" class="py-2 flex items-center justify-between gap-3">
+          <span class="font-medium">{{ alert.category }}</span>
+          <span :class="alert.overBudget ? 'text-red-600' : 'text-amber-600'">{{ alert.percent.toFixed(0) }}% used</span>
+        </li>
+      </ul>
+      <p v-else class="text-sm text-gray-500">No budget alerts for the selected filters.</p>
+    </section>
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div class="bg-white rounded-lg shadow p-4">


### PR DESCRIPTION
### Motivation
- Provide category-level monthly budget limits so users can set spending goals and see progress in the dashboard. 
- Surface near/over-budget alerts in Reports to make it easier to spot categories that need attention.

### Description
- Added a persisted budgets storage using `localStorage` under the key `budget_analyzer_budgets_v1` and helper functions `loadBudgets` / `saveBudgets` in `src/store/expenses.js`.
- Extended the Pinia store with `budgets` state, getters `budgetProgress` and `budgetAlerts`, and actions `setBudget` and `removeBudget` to manage budgets and compute spent/percent/overBudget per category.
- Added a new UI component `src/components/BudgetPlanner.vue` that allows creating/removing category budgets and shows progress bars and over-budget indicators.
- Integrated the planner into the dashboard (`src/views/Dashboard.vue`) and added a Budget Health section to Reports (`src/views/Reports.vue`) to list categories at/above 80% of budget usage.
- Updated `README.md` to document the new budget tracking feature and the added component.

### Testing
- Ran a production build with `npm run build` and the build completed successfully (dist artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b77152bd483259a1b788117415e0a)